### PR TITLE
feat: Add payment status information to data for order email

### DIFF
--- a/imports/plugins/core/orders/server/no-meteor/util/getDataForOrderEmail.js
+++ b/imports/plugins/core/orders/server/no-meteor/util/getDataForOrderEmail.js
@@ -5,6 +5,14 @@ import { getPaymentMethodConfigByName } from "/imports/plugins/core/payments/ser
 import { addAnonymousOrderToken } from "./anonymousToken";
 import * as R from "ramda";
 
+const PaymentStatus = {
+  created: "created",
+  completed: "completed",
+  canceled: "canceled",
+  failed: "failed"
+};
+
+
 /**
  * @name formatDateForEmail
  * @method
@@ -215,7 +223,11 @@ export default async function getDataForOrderEmail(context, { order }) {
         isInAdvance,
         isInSantanderManual,
         isCashpresso,
-        bankDetails
+        bankDetails,
+        isCreated: payment.status === PaymentStatus.created,
+        isFailed: payment.status === PaymentStatus.failed,
+        isCompleted: payment.status === PaymentStatus.completed,
+        isCanceled: payment.status === PaymentStatus.canceled
       })),
       subtotal: formatMoney(subtotal * userCurrencyExchangeRate, userCurrency),
       shipping: formatMoney(shippingCost * userCurrencyExchangeRate, userCurrency),


### PR DESCRIPTION
When we send email to shop, we need to send the current status of payment.
Currently payment status is sent in english language.
Handlebars.js does not support else if based on string such as  `if this.paymentStatus === "created"`, so we need booleans and we check `if this.isCreated`.
