### PR TITLE
fix: Search for primary shop by primary attribute, not domain

### DIFF
--- a/imports/node-app/core-services/shop/queries/index.js
+++ b/imports/node-app/core-services/shop/queries/index.js
@@ -1,18 +1,13 @@
 /* eslint-disable node/no-deprecated-api */
 /* TODO: revisit `url.parse` throughout Reaction */
-import url from "url";
 
 export default {
   shopById: (context, _id) => context.dataLoaders.Shops.load(_id),
   shopBySlug: (context, slug) => context.collections.Shops.findOne({ slug }),
   primaryShop: async (context) => {
-    const { collections, rootUrl } = context;
+    const { collections } = context;
     const { Shops } = collections;
-    const domain = url.parse(rootUrl).hostname;
-    let shop = await Shops.findOne({ domains: domain });
-    if (!shop) {
-      shop = await Shops.findOne({ shopType: "primary" });
-    }
+    const shop = await Shops.findOne({ shopType: "primary" });
     return shop;
   }
 };


### PR DESCRIPTION
primaryShop query is currently searching first by domain and then by shopType.

In order to avoid confusion primaryShop should query by what it says it queries, shopType.