### PR TITLE
feat ASANA-1167836493427377: Invalidate shipping method selection on …

### DIFF
--- a/imports/node-app/core-services/cart/mutations/setShippingAddressOnCart.js
+++ b/imports/node-app/core-services/cart/mutations/setShippingAddressOnCart.js
@@ -1,4 +1,5 @@
 import SimpleSchema from "simpl-schema";
+import * as R from 'ramda'
 import Random from "@reactioncommerce/random";
 import { CartAddress as AddressSchema } from "../simpleSchemas.js";
 import getCartById from "../util/getCartById.js";
@@ -37,7 +38,10 @@ export default async function setShippingAddressOnCart(context, input) {
   const updatedFulfillmentGroups = (cart.shipping || []).map((group) => {
     if (group.type === "shipping") {
       didModify = true;
-      return { ...group, address };
+      // shipmentMethod contains whether shipment has been selected
+      // we need to deselect shipmentMethod on shipping address change
+      // because depending on shipping address different options are provided
+      return { ...R.omit(['shipmentMethod'], group), address };
     }
     return group;
   });


### PR DESCRIPTION
Shipping methods needs to be deselected to avoid the following error:
1. User go through checkout (not completing payment) process with selecting DE as shipping address.
2. Goes back to shipping address and change country to SL.
3. Go back to payment method. Shipment method will remain selected with price 0.