### PR TITLE
feat: Remove error log on token expiration

### DIFF
--- a/imports/node-app/core-services/account/util/getUserFromAuthToken.js
+++ b/imports/node-app/core-services/account/util/getUserFromAuthToken.js
@@ -23,7 +23,6 @@ async function getUserFromAuthToken(loginToken, context) {
   const tokenObj = await expandAuthToken(token);
 
   if (tokenObj && !tokenObj.active) {
-    Logger.error("Bearer token is not active");
     throw new ReactionError("access-denied", "Token invalid or expired");
   } else if (tokenObj && tokenObj.token_type && tokenObj.token_type !== "access_token") {
     Logger.error("Bearer token is not an access token");


### PR DESCRIPTION
Removes the following log from spamming the console.
This "error" occurs every time authentication token expires, which is not really an error, but expected behaviour.
```
{"name":"Reaction","hostname":"...","pid":1,"level":50,"msg":"Bearer token is not active","time":"2020-09-06T19:59:43.237Z","v":0}
```